### PR TITLE
Removed the labs navbar link .

### DIFF
--- a/index.html
+++ b/index.html
@@ -142,9 +142,6 @@
                 <li>
                   <a href="//wiki.mozilla.org/ReMo" class="main">Wiki</a>
                 </li>
-                <li>
-                  <a href="//reps.mozilla.org/labs" class="main">Labs</a>
-                </li>
                 <li class="last">
                   <a href="//reps.mozilla.org/faq/" class="main">FAQ</a>
                 </li>


### PR DESCRIPTION
Removed the navbar link from planets page leading to http://reps.mozilla.org/labs.
which is not active anymore.